### PR TITLE
Fix call to datetime.utcnow which is deprecated

### DIFF
--- a/python/database.py
+++ b/python/database.py
@@ -2,7 +2,7 @@ import logging
 
 from sqlalchemy import create_engine, Column, Integer, String, DateTime
 from sqlalchemy.orm import sessionmaker, declarative_base
-from datetime import datetime
+from datetime import datetime, timezone
 from sqlalchemy.exc import IntegrityError
 
 log = logging.getLogger(__name__)
@@ -19,7 +19,7 @@ class User(Base):
     username = Column(String, nullable=False)
     email = Column(String, unique=True, nullable=False)
     password_hash = Column(String, nullable=False)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=datetime.now(timezone.utc))
     
     def __repr__(self):
         return f"<User(id={self.id}, username='{self.username}', email='{self.email}')>"


### PR DESCRIPTION
`datetime.utcnow` is now deprecated. I've replaced it with `datetime.now(timezone.utc)`
![image](https://github.com/user-attachments/assets/4f82b634-d240-4b21-a6ac-984f48f852bd)
